### PR TITLE
fix: add workaround for taskw character encoding

### DIFF
--- a/tests/test_hook_runner.py
+++ b/tests/test_hook_runner.py
@@ -67,7 +67,7 @@ def test_to_output(tw):
                 'description': 'yoooooo'
             }],
             'status': 'pending',
-            'description': 'Fix tw-98765 \N{winking face}',
+            'description': 'Fix tw-98765 [\N{winking face}]',
             'tags': ['in', 'next'],
             'modified': NOW.strftime(DATE_FORMAT),
             'entry': NOW.strftime(DATE_FORMAT),
@@ -80,7 +80,7 @@ def test_to_output(tw):
             '{',
             '"annotations":[{"entry":"20190103T051020Z","description":"yoooooo"}],',
             '"status":"pending",',
-            '"description":"Fix tw-98765 \N{winking face}",',
+            '"description":"Fix tw-98765 [\N{winking face}]",',
             '"tags":"in,next",',
             f'"modified":"{NOW.strftime(DATE_FORMAT)}",',
             f'"entry":"{NOW.strftime(DATE_FORMAT)}",',

--- a/twpm/hook_runner.py
+++ b/twpm/hook_runner.py
@@ -10,6 +10,7 @@ import six
 from taskw_ng import TaskWarrior
 from taskw_ng.fields import AnnotationArrayField
 from taskw_ng.fields import ArrayField
+from taskw_ng.fields import StringField
 from taskw_ng.task import Task
 from taskw_ng.utils import DATE_FORMAT
 
@@ -93,6 +94,14 @@ class HookRunner:
                     } for annotation in v
                 ]
                 serialized_task[k] = annotations
+            elif isinstance(field_type, StringField):
+                if v is None:
+                    serialized_task[k] = v
+                if not isinstance(v, str):
+                    string_value = str(v)
+                    logger.debug("Value %s serialized to string as '%s'", repr(v), string_value)
+                    v = string_value
+                serialized_task[k] = v
             else:
                 serialized_task[k] = task._serialize(k, v, task._fields)  # pylint: disable=protected-access
         return json.dumps(serialized_task, separators=(',', ':'), ensure_ascii=False)


### PR DESCRIPTION
## Summary

Add custom serialization logic for `StringField` as a workaround for taskw character encoding. This fix resolves issues like the ones mentioned in https://github.com/GothenburgBitFactory/bugwarrior/issues/1104.